### PR TITLE
Add basic auth option for dev

### DIFF
--- a/backend/api/request.py
+++ b/backend/api/request.py
@@ -1,0 +1,20 @@
+import datetime
+from core import userManager
+
+
+def get_identity_by_basic_auth(request):
+    if request.authorization is None:
+        return None
+    else:
+        username = request.authorization.get("username", None)
+        password = request.authorization.get("password", "")
+        user = userManager.getUser(username)
+        if user is not None and password != "" and user.checkPassword(password):
+            return username
+
+
+def get_expire_datetime_by_raw_jwt(raw_jwt):
+    if "exp" in raw_jwt:
+        return datetime.datetime.fromtimestamp(raw_jwt["exp"])
+    else:
+        return None

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -21,13 +21,14 @@ __credits__ = []
 __license__ = "GPLv3"
 
 from api import api_bp
-from flask import request, make_response
+from flask import request, make_response, current_app
 from flask_jwt_extended import jwt_optional, get_jwt_identity, get_raw_jwt
 from pprint import pprint
 import json
 from core import actionManager
 from api.request import get_identity_by_basic_auth, get_expire_datetime_by_raw_jwt
 import datetime
+
 
 # this module routes the action based api on e.g. .../api/v1
 # the api needs the generalized action based json-rpc form
@@ -46,7 +47,7 @@ def api_v1():
     identity = get_jwt_identity()
 
     # if jwt not found try to get identity by basic auth
-    if identity is None:
+    if identity is None and current_app.config["SYSTEM_ALLOW_BASIC_AUTH"]:
         identity = get_identity_by_basic_auth(request)
 
     # try to get expire date for jwt auth

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -26,6 +26,7 @@ from flask_jwt_extended import jwt_optional, get_jwt_identity, get_raw_jwt
 from pprint import pprint
 import json
 from core import actionManager
+from api.request import get_identity_by_basic_auth, get_expire_datetime_by_raw_jwt
 import datetime
 
 # this module routes the action based api on e.g. .../api/v1
@@ -40,11 +41,19 @@ def api_v1():
     print("call on api version v1")
     # pprint(request.json, indent=2)
     pprint(request.json, depth=2, indent=2)
-    a = get_raw_jwt()
-    expire_date = None
-    if "exp" in a:
-        expire_date = datetime.datetime.fromtimestamp(a["exp"])
-    reply = actionManager.handleActionRequest(get_jwt_identity(), expire_date, request.json)
+
+    # try to get identity by jwt
+    identity = get_jwt_identity()
+
+    # if jwt not found try to get identity by basic auth
+    if identity is None:
+        identity = get_identity_by_basic_auth(request)
+
+    # try to get expire date for jwt auth
+    expire_date = get_expire_datetime_by_raw_jwt(get_raw_jwt())
+
+    # handle action
+    reply = actionManager.handleActionRequest(identity, expire_date, request.json)
     print("Send reply:")
     pprint(reply, depth=2, indent=2)
     reply = json.dumps(reply)

--- a/backend/config.py
+++ b/backend/config.py
@@ -145,5 +145,4 @@ def configure_app(app, config, test):
 
     app.config["SYSTEM_ALLOW_BASIC_AUTH"] = config["DEV"].get("allow_basic_authentication", False)
 
-
     # app.config.from_pyfile('config.cfg', silent=True) # instance-folders configuration

--- a/backend/config.py
+++ b/backend/config.py
@@ -85,6 +85,7 @@ def load_config(file):
     cfg_parser.add_section("LDAP")
     cfg_parser.add_section("MAIL")
     cfg_parser.add_section("SYSTEM")
+    cfg_parser.add_section("DEV")
     # read and overwrite
     cfg_parser.read(file)
     data = json.loads(json.dumps(cfg_parser._sections))
@@ -140,6 +141,9 @@ def configure_app(app, config, test):
     app.config["MAIL_PASSWORD"] = config["MAIL"].get("password", "password")
     app.config["MAIL_USE_TLS"] = config["MAIL"].get("tls", False)
     app.config["MAIL_USE_SSL"] = config["MAIL"].get("ssl", True)
-    app.config["MAIL_SENDER"] = config["MAIL"].get("sender", "test@test.com")
+    app.config["MAIL_SENDER"] = config["MAIL"].get("sender", "")
+
+    app.config["SYSTEM_ALLOW_BASIC_AUTH"] = config["DEV"].get("allow_basic_authentication", False)
+
 
     # app.config.from_pyfile('config.cfg', silent=True) # instance-folders configuration

--- a/backend/config.template
+++ b/backend/config.template
@@ -15,3 +15,6 @@ username="your.mailserver.username.org"
 password="your.mailserver.password.org"
 tls=False
 ssl=True
+
+[DEV]
+allow_basic_authentication = False


### PR DESCRIPTION
As a developer I want to authenticate by HTTP Basic Auth header with username and password to test and convinience.

This pull request add basic auth to authenticate (next to the session based jwt)

In referennce to the "Starter Tutorial" this might be useful.